### PR TITLE
Install mycli 1.8.1 via pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ None.
 Role Variables
 --------------
 
-None.
+```
+mycli_version: 1.8.1
+```
+The version of mycli to install.
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
 # defaults file for mycli
+
+mycli_version: 1.8.1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,12 @@
 ---
 # Setup/install tasks.
+
 - include: setup-RedHat.yml
   when: ansible_os_family == 'RedHat'
 
 - include: setup-Debian.yml
   when: ansible_os_family == 'Debian'
+
+- name: Install mycli via pip.
+  pip: "name=mycli version={{ mycli_version }}"
+  become: yes

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,30 +1,10 @@
 ---
-# ref: https://github.com/dbcli/mycli/blob/v1.5.2/README.md#debianubuntu-package
-
-- name: Add the gpg key for packagecloud for package verification.
-  apt_key:
-    url: https://packagecloud.io/gpg.key
-    keyring: /etc/apt/trusted.gpg.d/packagecloud.gpg
-    state: present
+# ref: https://github.com/dbcli/mycli/blob/v1.8.1/README.md#quick-start
 
 - name: Update apt cache.
   apt: update_cache=yes cache_valid_time=86400
+  become: yes
 
-- name: Install apt-transport-https.
-  apt: name=apt-transport-https state=latest
-
-- name: Add the mycli package repo to the apt source.
-  apt_repository:
-    repo: "deb https://packagecloud.io/amjith/mycli/ubuntu/ trusty main"
-    state: present
-
-- name: Check if mycli is already installed.
-  stat: path=/usr/share/python/mycli/bin/mycli
-  register: mycli_installed
-
-- name: Update apt cache if mycli is not yet installed.
-  apt: update_cache=yes
-  when: mycli_installed.stat.exists == false
-
-- name: Install mycli.
-  apt: name=mycli state=latest
+- name: Install python-pip via apt.
+  apt: "name=python-pip state=installed"
+  become: yes

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,7 +1,6 @@
 ---
-# ref: https://github.com/dbcli/mycli/blob/v1.5.2/README.md#rhel-centos-fedora
+# ref: https://github.com/dbcli/mycli/blob/v1.8.1/README.md
 
-- name: Ensure MySQL packages are installed.
+- name: Install python-pip via yum.
   yum: "name=python-pip state=installed"
-
-- pip: name=mycli
+  become: yes


### PR DESCRIPTION
#### Because:

* The Debian/Ubuntu packages on packagecloud.io are no longer supported,
  so the latest version available from packagecloud was 1.5.2.
* There is now an official package available for Ubuntu 16.04, but no
  up to date package for 14.04 or 12.04, so it's simplest just to
  install from pip everywhere.

#### This change:

* Install via `pip` on Debian/Ubuntu.
* Define `become` for the root tasks. The role shouldn't expect
  `become: yes` from the play.
* Adds a `mycli_version: 1.8.1` default.

#### Notes:

* Users who previously installed `mycli` via `apt` will need to
  uninstall the package before running this role to install the latest
  version via `pip`:

```
sudo apt-get remove mycli
```