### PR TITLE
Install `python-dev` dependency on Debian/Ubuntu

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -8,3 +8,9 @@
 - name: Install python-pip via apt.
   apt: "name=python-pip state=installed"
   become: yes
+
+- name: Install mycli dependencies via apt.
+  apt: "name={{ item }} state=installed"
+  become: yes
+  with_items:
+    - python-dev  # required by pycrypto


### PR DESCRIPTION
#### Because:

* `python-dev` is required by `pycrypto` which is a requirement of the
  `mycli` `pip` package, ref:
  https://github.com/dbcli/mycli/blob/v1.8.1/setup.py#L27
* `python-dev` is not present in all cases by default, though it is
  present on the Travis CI container - which is why this wasn't caught
  by CI.